### PR TITLE
fix(celery): correct task chaining logic and switch to Redis backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,18 @@ DOCKER_NETWORK_NAME=tvorcha-network
 DOCKER_VOLUME_NAME=tvorcha-efs
 DOCKER_VOLUME_PATH=D:/tvorcha-lavka
 
+# --- Redis ------------------------------------------------------------------------------------------------------------
+REDIS_PORT=6379
+REDIS_BROKER_URL="redis://redis:${REDIS_PORT}/0"
+
 # --- RabbitMQ ---------------------------------------------------------------------------------------------------------
 RABBITMQ_DEFAULT_USER=admin
 RABBITMQ_DEFAULT_PASS=admin
 
 RABBITMQ_HOST=rabbitmq
 RABBITMQ_PORT=5672
-RABBITMQ_BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//
+RABBITMQ_BROKER_URL="pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//"
 
 # --- Celery -----------------------------------------------------------------------------------------------------------
-CELERY_BROKER_URL=${RABBITMQ_BROKER_URL}
-CELERY_RESULT_BACKEND=rpc://
+CELERY_BROKER_URL="${RABBITMQ_BROKER_URL}"
+CELERY_RESULT_BACKEND="${REDIS_BROKER_URL}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ celery = "^5.5.1"
 pydantic = "^2.11.3"
 pillow = "^11.2.1"
 pillow-heif = "^0.22.0"
+redis = "^6.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.2.0"

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -13,7 +13,7 @@ def main() -> None:
         "worker",
         "--pool=solo",
         "--concurrency=2",
-        "--queues=optimize.queue",
+        "--queues=file-optimizer.queue",
         "--max-tasks-per-child=20",
         "--hostname=file-optimizer@%h",
         "--loglevel=%s" % settings.LOGGING_LEVEL_CONSOLE,

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,7 +5,7 @@ source /scripts/logging.sh
 BASE_FLAGS=(
   "--pool=prefork"
   "--concurrency=2"
-  "--queues=optimize.queue"
+  "--queues=file-optimizer.queue"
   "--max-tasks-per-child=20"
   "--hostname=file-optimizer@%h"
   "--loglevel=info"

--- a/src/core/config/celery.py
+++ b/src/core/config/celery.py
@@ -4,7 +4,7 @@ from pydantic.v1 import BaseSettings
 class CelerySettings(BaseSettings):
     APP_NAME: str = "file-optimizer"
     CELERY_BROKER_URL: str = "pyamqp://admin:admin@rabbitmq:5672//"
-    CELERY_RESULT_BACKEND: str = "rpc://"
+    CELERY_RESULT_BACKEND: str = "redis://redis:6379/0"
 
 
 celery_settings = CelerySettings()

--- a/src/tasks/schemas.py
+++ b/src/tasks/schemas.py
@@ -15,7 +15,7 @@ class OptimizeProductImages(BaseModel):
     product_id: UUID
 
 
-class UploadFilesToS3(BaseModel):
+class UploadProductImageData(BaseModel):
     """
     Data Transfer Object
     for uploading files to S3 task.

--- a/src/tasks/task_optimize_images.py
+++ b/src/tasks/task_optimize_images.py
@@ -6,13 +6,13 @@ from core.exceptions import ImageProcessingError, NoAnyImageFiles, NoOriginalIma
 from main import app
 from processors import ImageOptimizeProcessor
 
-from .schemas import OptimizeProductImages, UploadFilesToS3
+from .schemas import OptimizeProductImages, UploadProductImageData
 
 logger = getLogger("celery.optimize")
 
 
-@app.task(name="optimize.product.images", queue="optimize.queue", bind=True, max_retries=3)
-def optimize_product_images_task(self: Task, json_str: str) -> None:
+@app.task(name="optimize.product.images", queue="file-optimizer.queue", bind=True)
+def optimize_product_images_task(self: Task, json_str: str) -> str | None:
     """Optimizes images and sends them to upload process."""
     # Validate the data
     data = OptimizeProductImages.model_validate_json(json_str)
@@ -27,23 +27,16 @@ def optimize_product_images_task(self: Task, json_str: str) -> None:
         raise self.retry(exc=e)
 
     except NoAnyImageFiles:
-        return
+        logger.info("No data to process. Product ID: %s", data.product_id)
+        return None
 
     except NoOriginalImageFiles:
         pass
 
     # Preparing data to transfer to the next task
-    upload_data = UploadFilesToS3(
+    next_task_data = UploadProductImageData(
         processed_files_dir=processor.processed_files_dir,
         product_id=data.product_id,
     )
 
-    # Send task to upload files
-    logger.debug("Sending task to upload files...")
-
-    # Call the next task
-    app.send_task(
-        name="upload.s3.product.images",
-        queue="upload.queue",
-        kwargs={"json_str": upload_data.model_dump_json()},
-    )
+    return next_task_data.model_dump_json()

--- a/tests/test_tasks/test_task_optimize_images.py
+++ b/tests/test_tasks/test_task_optimize_images.py
@@ -6,10 +6,9 @@ from celery.exceptions import Retry  # type: ignore
 from pytest_mock import MockerFixture
 
 from core.exceptions import ImageProcessingError, NoAnyImageFiles, NoOriginalImageFiles
-from main import app
 from processors import ImageOptimizeProcessor
 from tasks import optimize_product_images_task
-from tasks.schemas import OptimizeProductImages, UploadFilesToS3
+from tasks.schemas import OptimizeProductImages, UploadProductImageData
 
 
 class TestOptimizeImagesTask:
@@ -19,12 +18,12 @@ class TestOptimizeImagesTask:
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
-        "exception, expected_exception, should_call_next_task",
+        "exception, expected_exception",
         [
-            (None, None, True),
-            (NoAnyImageFiles, None, False),
-            (NoOriginalImageFiles, None, True),
-            (ImageProcessingError, Retry, False),
+            (None, None),
+            (NoAnyImageFiles, None),
+            (NoOriginalImageFiles, None),
+            (ImageProcessingError, Retry),
         ],
     )
     def test_optimize_product_images_task(
@@ -32,12 +31,10 @@ class TestOptimizeImagesTask:
         mocker: MockerFixture,
         exception: type[Exception] | None,
         expected_exception: type[Exception] | None,
-        should_call_next_task: bool,
     ) -> None:
         """Success case of process files task."""
         # Patch `process` method to not call the real logic
         process_mock = mocker.patch.object(ImageOptimizeProcessor, "process", side_effect=exception)
-        next_task_call = mocker.patch.object(app, "send_task")
 
         # Preparing data to transfer to the task
         optimize_dto = OptimizeProductImages(
@@ -53,26 +50,21 @@ class TestOptimizeImagesTask:
                 kwargs={"json_str": optimize_dto.model_dump_json()},
             )
 
-        if not expected_exception:
-            # Check that the `upload` method has been called
-            process_mock.assert_called_once_with()
+        if expected_exception:
+            return
 
-            # Check that the task completed successfully
-            assert result.status == states.SUCCESS
+        # Check that the `upload` method has been called
+        process_mock.assert_called_once_with()
 
-            if should_call_next_task:
-                # Preparing data to transfer to the next task
-                upload_data = UploadFilesToS3(
-                    processed_files_dir=self.processor.processed_files_dir,  # noqa
-                    product_id=self.processor._product_id,
-                )
-                # Check that the next task has been called with the correct arguments
-                next_task_call.assert_called_once_with(
-                    name="upload.s3.product.images",
-                    queue="upload.queue",
-                    kwargs={"json_str": upload_data.model_dump_json()},
-                )
-            else:
-                next_task_call.assert_not_called()
+        # Check that the task completed successfully
+        assert result.status == states.SUCCESS
+
+        if isinstance(result.result, str):
+            # Preparing data to transfer to the next task
+            next_task_data = UploadProductImageData(
+                processed_files_dir=self.processor.processed_files_dir,  # noqa
+                product_id=self.processor._product_id,
+            )
+            assert result.result == next_task_data.model_dump_json()
         else:
-            next_task_call.assert_not_called()
+            assert result.result is None


### PR DESCRIPTION
- Task now returns data for the next task in the chain instead of launching it directly
- Queue name updated to reflect current naming conventions
- Switched Celery result backend from RPC to Redis for better reliability and visibility
- Installed `redis` library for backend support
- Updated `.env.example` with Redis backend settings